### PR TITLE
Bump to checkstyle 8.32->8.33

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV REVIEWDOG_COMMIT=144be8f5064d263cdd674952163da0cebd0247d0
 ENV REVIEWDOG_VERSION=v0.10.0
 
 # Grab checkstyle
-RUN wget -O - -q https://github.com/checkstyle/checkstyle/releases/download/checkstyle-8.32/checkstyle-8.32-all.jar > /checkstyle.jar
+RUN wget -O - -q https://github.com/checkstyle/checkstyle/releases/download/checkstyle-8.33/checkstyle-8.33-all.jar > /checkstyle.jar
 
 # Grab reviewdog
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/${REVIEWDOG_COMMIT}/install.sh| sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}


### PR DESCRIPTION
Details:

This is the version of checkstyle used by the latest Intellj plugin.
This is not the latest released version.

There haven't been incompatibility issues and I don't think we need to maintain this
strict comptability in perpetuity but it's a nice-to-have.