### PR TITLE
Adding checkstyle for todo comments

### DIFF
--- a/checkstyle-circle.xml
+++ b/checkstyle-circle.xml
@@ -252,5 +252,10 @@
             <property name="exceptionVariableName" value="expected"/>
         </module>
         <module name="CommentsIndentation"/>
+        <module name="TodoComment">
+          <property name="id" value="commentStartWithSpace"/>
+          <property name="format" value="^([^\s\/*])"/>
+          <message key="todo.match" value="Comment text should start with space."/>
+        </module>
     </module>
 </module>


### PR DESCRIPTION
Got a PR comment to fix one of my simple todo comments to include a space after //. Noticed we didn't have this in our checkstyle. 

Looking at https://github.com/checkstyle/checkstyle/issues/8137 it's not fully defined yet how they will do it, but pbludov and romani committed this fix: https://github.com/checkstyle/checkstyle/commit/dbac7fb8e605c3f29172d7f4a894b1b91e380edc

This TodoComment module should get most simple cases like:
//violation
// OK