### PR TITLE
Revert "Adding checkstyle for todo comments"

### DIFF
--- a/checkstyle-circle.xml
+++ b/checkstyle-circle.xml
@@ -252,10 +252,5 @@
             <property name="exceptionVariableName" value="expected"/>
         </module>
         <module name="CommentsIndentation"/>
-        <module name="TodoComment">
-          <property name="id" value="commentStartWithSpace"/>
-          <property name="format" value="^([^\s\/*])"/>
-          <message key="todo.match" value="Comment text should start with space."/>
-        </module>
     </module>
 </module>


### PR DESCRIPTION
Reverts circlefin/actions-checkstyle#4

Sorry @TerjeBratlie-circle I have to revert this. There are some edge cases we didn't consider, specifically `//noinspection` that are generated by IntelliJ without spaces. For now I'm going to remove it (so that we can unblock anyone opening PRs), but we can discuss improving the regex on Monday.