### PR TITLE
Allow for module-info.java in Circle projects

### DIFF
--- a/checkstyle-circle.xml
+++ b/checkstyle-circle.xml
@@ -37,6 +37,11 @@
         <property name="eachLine" value="true"/>
     </module>
 
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="module\-info\.java$"/>
+    </module>
+
+
     <module name="TreeWalker">
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">


### PR DESCRIPTION
Allows for module-info.java in Circle projects (JDK9+).

As it is, builds fail with both: 
<img width="1366" alt="Screen Shot 2022-02-16 at 5 22 57 PM" src="https://user-images.githubusercontent.com/87335799/154367467-163351b1-c32e-4c9f-9365-d6a12672560a.png">

And maven:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:3.1.1:check (default-cli) on project type-qual: Failed during checkstyle configuration: Exception was thrown while processing /Users/scott.serbousek/workspace/risk/type-qual/src/main/java/module-info.java: NoViableAltException occurred while parsing file /Users/scott.serbousek/workspace/risk/type-qual/src/main/java/module-info.java. unexpected token: module -> [Help 1]
```