### PR TITLE
[INFRA-682] allow empty constructors

### DIFF
--- a/checkstyle-circle.xml
+++ b/checkstyle-circle.xml
@@ -11,6 +11,7 @@
    - Add UnusedImports
    - Remove PLUS from operator newline required
    - Remove VariableDeclarationUsageDistance
+   - The opening and closing curly brace of an empty constructor body can be on the same line
  -->
 
 <!--
@@ -76,8 +77,13 @@
             <property name="id" value="RightCurlyAlone"/>
             <property name="option" value="alone"/>
             <property name="tokens"
-             value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
-                    INSTANCE_INIT"/>
+             value="CLASS_DEF, METHOD_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
+        </module>
+        <module name="RightCurly">
+            <property name="id" value="RightCurlyAloneOrSingleLine"/>
+            <property name="option" value="alone_or_singleline"/>
+            <property name="tokens"
+             value="CTOR_DEF"/>
         </module>
         <module name="WhitespaceAround">
             <property name="allowEmptyConstructors" value="true"/>


### PR DESCRIPTION
# Context
Our [style guide](https://circlepay.atlassian.net/wiki/spaces/ENGINEERIN/pages/386957608/Circle+Java+Style+Guide#Empty-blocks%3A-may-be-concise) allows for empty blocks, but our Checkstyle does not. This change fixes that.

# Prior to this change
This was illegal:
```java
class Hello {
    Hello() {}
}
```

It gave the error
```
(extension) RightCurlyAlone: '}' at column 14 should be alone on a line.
```

# With this change
This is legal:
```java
class Hello {
    Hello() {}
}
```

This is legal, too:
```java
class Hello {
    Hello() {
    }
}
```

This is still *illegal*:
```java
class Hello {
    Hello() { cannotDoThis(); }
}
```

# Testing
This change passes on these repos:
- entity-service
- transaction-core
- risk
- ARC
- EFT