### PR TITLE
[INFRA-682] allow empty methods

### DIFF
--- a/checkstyle-circle.xml
+++ b/checkstyle-circle.xml
@@ -11,7 +11,7 @@
    - Add UnusedImports
    - Remove PLUS from operator newline required
    - Remove VariableDeclarationUsageDistance
-   - The opening and closing curly brace of an empty constructor body can be on the same line
+   - The opening and closing curly brace of an empty constructor body or empty method body can be on the same line
  -->
 
 <!--
@@ -77,13 +77,12 @@
             <property name="id" value="RightCurlyAlone"/>
             <property name="option" value="alone"/>
             <property name="tokens"
-             value="CLASS_DEF, METHOD_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
+             value="CLASS_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
         </module>
         <module name="RightCurly">
             <property name="id" value="RightCurlyAloneOrSingleLine"/>
             <property name="option" value="alone_or_singleline"/>
-            <property name="tokens"
-             value="CTOR_DEF"/>
+            <property name="tokens" value="CTOR_DEF, METHOD_DEF"/>
         </module>
         <module name="WhitespaceAround">
             <property name="allowEmptyConstructors" value="true"/>


### PR DESCRIPTION
# Context
Our [style guide](https://circlepay.atlassian.net/wiki/spaces/ENGINEERIN/pages/386957608/Circle+Java+Style+Guide#Empty-blocks%3A-may-be-concise) allows for empty blocks, but our Checkstyle does not. This change fixes that.

# Prior to this change
This was illegal:
```java
class Hello {
    void method() {}
}
```

It gave the error
```
(extension) RightCurlyAlone: '}' at column 14 should be alone on a line.
```

# With this change
This is legal:
```java
class Hello {
    void method() {}
}
```

This is legal, too:
```java
class Hello {
    void method() {
    }
}
```

This is still *illegal*:
```java
class Hello {
    void method() { cannotDoThis(); }
}
```

# Testing
This change passes on these repos:
- entity-service
- transaction-core