### PR TITLE
[INFRA-1192] allow empty lambdas

### DIFF
--- a/checkstyle-circle.xml
+++ b/checkstyle-circle.xml
@@ -88,6 +88,7 @@
             <property name="allowEmptyConstructors" value="true"/>
             <property name="allowEmptyMethods" value="true"/>
             <property name="allowEmptyTypes" value="true"/>
+            <property name="allowEmptyLambdas" value="true"/>
             <property name="allowEmptyLoops" value="true"/>
             <message key="ws.notFollowed"
              value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>


### PR DESCRIPTION
# Context
Our [style guide](https://circlepay.atlassian.net/wiki/spaces/ENGINEERIN/pages/386957608/Circle+Java+Style+Guide#Empty-blocks%3A-may-be-concise) allows for empty blocks, but our Checkstyle does not. This change fixes that.

# Prior to this change
This was illegal:
```java
var lambda = () -> {};
```

It gave the error
```
WhitespaceAround: '{' is not followed by whitespace. Empty blocks may only be represented as {} when not part of a multi-block statement (4.1.3)
WhitespaceAround: '}' is not preceded with whitespace.
```

# With this change
This is legal:
```java
var lambda = () -> {};
```

This is legal, too:
```java
var lambda = () -> {
};
```

This is still *illegal*:
```java
var lambda = () -> { doSomething(); };
```

# Testing
This change passes on these repos:
- entity-service
- transaction-core