### PR TITLE
[no-story] allow empty blocks

### DIFF
--- a/checkstyle-circle.xml
+++ b/checkstyle-circle.xml
@@ -74,15 +74,9 @@
                     LITERAL_DO"/>
         </module>
         <module name="RightCurly">
-            <property name="id" value="RightCurlyAlone"/>
-            <property name="option" value="alone"/>
-            <property name="tokens"
-             value="CLASS_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
-        </module>
-        <module name="RightCurly">
             <property name="id" value="RightCurlyAloneOrSingleLine"/>
             <property name="option" value="alone_or_singleline"/>
-            <property name="tokens" value="CTOR_DEF, METHOD_DEF"/>
+            <property name="tokens" value="CLASS_DEF, CTOR_DEF, INSTANCE_INIT, LITERAL_FOR, LITERAL_WHILE, METHOD_DEF, STATIC_INIT"/>
         </module>
         <module name="WhitespaceAround">
             <property name="allowEmptyConstructors" value="true"/>


### PR DESCRIPTION
## Summary
Our [style guide](https://circlepay.atlassian.net/wiki/spaces/ENGINEERIN/pages/386957608/Circle+Java+Style+Guide#Empty-blocks%3A-may-be-concise) allows for empty blocks. We update our Checkstyle to allow empty blocks, too.

## Detail
### Prior to this change
This was illegal:
```java
class Clazz {}
```

### With this change
This is legal:
```java
class Clazz {}
```

This is legal, too:
```java
class Clazz {
}
```

This is still illegal:
```java
class Class { private String field; }
```

## Testing
This change passes on entity-service & transaction-core.

## Documentation
None.

---

**Requested Reviewers:** @asharp-circle @creilly12 @istvancircle @rschmitz-circle 