### PR TITLE
(pending more testing) feat: disallow multiple empty lines inside class members for consistency

### DIFF
--- a/checkstyle-circle.xml
+++ b/checkstyle-circle.xml
@@ -98,6 +98,7 @@
         <module name="ModifierOrder"/>
         <module name="EmptyLineSeparator">
             <property name="allowNoEmptyLineBetweenFields" value="true"/>
+            <property name="allowMultipleEmptyLinesInsideClassMembers" value="false"/>
         </module>
         <module name="SeparatorWrap">
             <property name="id" value="SeparatorWrapDot"/>


### PR DESCRIPTION
## Summary

Following up on https://github.com/circlefin/rewrite-common/pull/1#discussion_r1739335856

The blank line pattern could be inconsistent with the current style configuration, this PR proposes to fail multiple blank lines inside class members.

## Testing
I ran the checkstyle locally against the project and confirmed that it fails as expected: https://github.com/circlefin/rewrite-common/pull/1
